### PR TITLE
Improve responsive layout + typography

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -34,7 +34,7 @@ h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
 %vertical-rhythm {
-  margin-bottom: $spacing-unit / 2;
+  margin-bottom: $spacing-unit / 1.5;
 }
 
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -3,8 +3,8 @@
  */
 .site-header {
   width: 100%;
-  height:80vh;
-  min-height: 400px;
+  height:30vh;
+  min-height: 330px;
   background-image: url(/assets/img/protest.jpg);
   background-size: cover;
   background-position: center;
@@ -284,19 +284,26 @@
 
 #stranded-button {
   margin-right:30px;
+  background-color: #00BBB6 /* Highlight call to action */
 }
 
-@media screen and (min-width: 401px) {
+.main-button {
+  font-size: 20px;
+  padding: 12px 14px;
+  display: block;
+}
+#stranded-button {
+  margin: 0 0 20px 0;
+}
+
+/* medium-ish phones and up */
+@media screen and (min-width: 481px) {
   .main-button {
-    font-size:25px;
-    padding:15px 20px;
+    font-size:24px;
+    padding:10px 16px;
+    display: inline-block;
+  }
+  #stranded-button {
+    margin-right:30px;
   }
 }
-
-@media screen and (max-width: 400px) {
-  .main-button {
-    font-size:14px;
-    padding:15px 20px;
-  }
-}
-

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -1,9 +1,11 @@
+@import "../viewport-units-ios";
 /**
  * Site header
  */
 .site-header {
+  @include viewport-unit(height, 30vh);
   width: 100%;
-  height:30vh;
+
   min-height: 330px;
   background-image: url(/assets/img/protest.jpg);
   background-size: cover;

--- a/_sass/viewport-units-ios.scss
+++ b/_sass/viewport-units-ios.scss
@@ -1,0 +1,63 @@
+
+/**
+ * Fix for vw, vh, vmin, vmax on iOS 7.
+ * http://caniuse.com/#feat=viewport-units
+ *
+ * This fix works by replacing viewport units with px values on known screen sizes.
+ *
+ * iPhone 6 and 6 Plus cannot run iOS 7, so are not targeted by this fix.
+ * Target devices running iOS 8+ will incidentally execute the media query,
+ * but this will still produce the expected result; so this is not a problem.
+ *
+ * As an example, replace:
+ *
+ *   height: 50vh;
+ *   font-size: 5vmin;
+ *
+ * with:
+ *
+ *   @include viewport-unit(height, 50vh);
+ *   @include viewport-unit(font-size, 5vmin);
+ */
+@mixin viewport-unit($property, $value) {
+  #{$property}: $value;
+
+  $unit: unit($value);
+
+  @if (index((vw, vh, vmin, vmax), $unit) != null) {
+    $devices: (
+      (768px, 1024px), // iPad (all versions)
+      (320px, 480px),  // iPhone 4
+      (320px, 568px)   // iPhone 5, 5C, 5S
+    );
+
+    @each $device in $devices {
+      $device-width: nth($device, 1);
+      $device-height: nth($device, 2);
+
+      $device-query: "only screen and (-webkit-min-device-pixel-ratio: 1)";
+      $device-query: "#{$device-query} and (device-width: #{$device-width})";
+      $device-query: "#{$device-query} and (device-height: #{$device-height})";
+
+      $percent: $value / ($value * 0 + 1); // see https://github.com/sass/sass/issues/533
+
+      $percent-width: $device-width * $percent / 100;
+      $percent-height: $device-height * $percent / 100;
+
+      @if ($unit == vmin or $unit == vmax) {
+        @media #{$device-query} {
+          #{$property}: if($unit == vmin, $percent-width, $percent-height);
+        }
+      }
+      @else {
+        @media #{$device-query} and (orientation: portrait) {
+          #{$property}: if($unit == vw, $percent-width, $percent-height);
+        }
+
+        @media #{$device-query} and (orientation: landscape) {
+          #{$property}: if($unit == vw, $percent-height, $percent-width);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- more whitespace
- shorter masthead
- nudge masthead breakpoint up to 480px
- stack buttons for smaller screens
- add emphasis color to refugee call to action
- apply fix suggested in #12 for older iOS on smaller screens