### PR TITLE
Add link to ACLU Affiliates Page

### DIFF
--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ Here’s what to know if you are denied entry to the United States:
 
 **3. Do not voluntarily abandon your green card** or lawful permanent resident application.
 
-**4. Ask for a lawyer.**
+**4. Ask for a lawyer.** If you are detained at an airport in the United States you can also request legal assistance from the American Civil Liberties Union by contacting their [local representative](https://www.aclu.org/about/affiliates?redirect=affiliates).
 
 If you are turned back:
 


### PR DESCRIPTION
ACLU is circulating contacts to provide legal assistance to those detained at US airports from their local ACLU state representative (e.g. for Boston Logan, refer to ACLU Massachusetts Contact). 

I propose adding a link to the ACLU map which shows local representative by state.
